### PR TITLE
Avoid getting stuck in an infinite loop

### DIFF
--- a/cpp/clipper.cpp
+++ b/cpp/clipper.cpp
@@ -1640,8 +1640,13 @@ void Clipper::FixHoleLinkage(OutRec &outrec)
       outrec.FirstLeft->Pts)) return;
 
   OutRec* orfl = outrec.FirstLeft;
-  while (orfl && ((orfl->IsHole == outrec.IsHole) || !orfl->Pts))
+  OutRec* first = orfl;
+  while (orfl && ((orfl->IsHole == outrec.IsHole) || !orfl->Pts)) {
       orfl = orfl->FirstLeft;
+      if (orfl == first) {
+          break;
+      }
+  }
   outrec.FirstLeft = orfl;
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
cc @flippmoke 

I don't know what's really going on here, but the Natural Earth `ne_10m_admin_0_countries` polygon for France gets stuck in this loop at z0 in Tippecanoe. Does this make any sense to you?
